### PR TITLE
fix: :bug: fix react infinite loop error

### DIFF
--- a/content/1-reactivity/2-update-state/react/Name.jsx
+++ b/content/1-reactivity/2-update-state/react/Name.jsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Name() {
   const [name, setName] = useState("John");
-  setName("Jane");
+
+  useEffect(() => setName("Jane"), []);
 
   return <h1>Hello {name}</h1>;
 }


### PR DESCRIPTION
Setting state in the body of the component will cause below error:
> Error
Too many re-renders. React limits the number of renders to prevent an infinite loop.

So to change name for once, it has to be run inside of useEffect:


```jsx
import { useEffect, useState } from "react";

export default function App() {
  const [name, setName] = useState("John");
  
  useEffect(()=>setName("Jane"),[])

  return <h1>Hello {name}</h1>;
}


```