### PR TITLE
refactor: :recycle: Add simpler way of passing functions to children in svelte

### DIFF
--- a/content/4-component-composition/2-emit-to-parent/svelte/AnswerButton.svelte
+++ b/content/4-component-composition/2-emit-to-parent/svelte/AnswerButton.svelte
@@ -1,17 +1,8 @@
 <script>
-  import { createEventDispatcher } from "svelte";
-
-  const dispatch = createEventDispatcher();
-
-  function clickYes() {
-    dispatch("yes");
-  }
-
-  function clickNo() {
-    dispatch("no");
-  }
+  export let onYes;
+  export let onNo;
 </script>
 
-<button on:click={clickYes}> YES </button>
+<button on:click={onYes}> YES </button>
 
-<button on:click={clickNo}> NO </button>
+<button on:click={onNo}> NO </button>

--- a/content/4-component-composition/2-emit-to-parent/svelte/App.svelte
+++ b/content/4-component-composition/2-emit-to-parent/svelte/App.svelte
@@ -13,5 +13,5 @@
 </script>
 
 <p>Are you happy?</p>
-<AnswerButton on:yes={onAnswerYes} on:no={onAnswerNo} />
+<AnswerButton onYes={onAnswerYes} onNo={onAnswerNo} />
 <p style="font-size: 50px;">{canCome ? "😀" : "😥"}</p>


### PR DESCRIPTION
Add more readable version of passing functions to children:

```html
<script>
        export let onYes;
	export let onNo;
</script>

<button on:click={onYes}> YES </button>
<button on:click={onNo}> NO </button>
```