### PR TITLE
Prefer `@query` over `ref()`

### DIFF
--- a/content/2-templating/5-dom-ref/lit/input-focused.js
+++ b/content/2-templating/5-dom-ref/lit/input-focused.js
@@ -1,16 +1,15 @@
 import { LitElement, html } from "lit";
-import { customElement, state } from "lit/decorators.js";
-import { ref, createRef } from "lit/directives/ref.js";
+import { customElement, state, query } from "lit/decorators.js";
 
 @customElement("input-focused")
 export class InputFocused extends LitElement {
-  inputRef = createRef();
+  @query('input') inputEl!: HTMLInputElement;
 
   firstUpdated() {
-    this.inputRef.value.focus();
+    this.inputEl.focus();
   }
 
   render() {
-    return html`<input type="text" ${ref(this.inputRef)} />`;
+    return html`<input type="text" />`;
   }
 }

--- a/content/2-templating/5-dom-ref/lit/input-focused.js
+++ b/content/2-templating/5-dom-ref/lit/input-focused.js
@@ -3,7 +3,7 @@ import { customElement, state, query } from "lit/decorators.js";
 
 @customElement("input-focused")
 export class InputFocused extends LitElement {
-  @query('input') inputEl!: HTMLInputElement;
+  @query('input') inputEl;
 
   firstUpdated() {
     this.inputEl.focus();


### PR DESCRIPTION
Lit team prefers suggesting `@query` over `ref`. Though this example is simple enough to just do `this.renderRoot.querySelector('input')!.focus()` as well, the title for this section is "dom-ref"