### PR TITLE
Change Vue 2 and Vue 3 examples to compact mode

### DIFF
--- a/content/2-templating/2-styling/vue2/CssStyle.vue
+++ b/content/2-templating/2-styling/vue2/CssStyle.vue
@@ -1,11 +1,7 @@
 <template>
   <div>
-    <h1 class="title">
-      I am red
-    </h1>
-    <button style="font-size: 10rem">
-      I am a button
-    </button>
+    <h1 class="title">I am red</h1>
+    <button style="font-size: 10rem">I am a button</button>
   </div>
 </template>
 

--- a/content/2-templating/2-styling/vue3/CssStyle.vue
+++ b/content/2-templating/2-styling/vue3/CssStyle.vue
@@ -1,10 +1,6 @@
 <template>
-  <h1 class="title">
-    I am red
-  </h1>
-  <button style="font-size: 10rem">
-    I am a button
-  </button>
+  <h1 class="title">I am red</h1>
+  <button style="font-size: 10rem">I am a button</button>
 </template>
 
 <style scoped>

--- a/content/2-templating/4-event-click/vue2/Counter.vue
+++ b/content/2-templating/4-event-click/vue2/Counter.vue
@@ -16,8 +16,6 @@ export default {
 <template>
   <div>
     <p>Counter: {{ count }}</p>
-    <button @click="incrementCount">
-      +1
-    </button>
+    <button @click="incrementCount">+1</button>
   </div>
 </template>

--- a/content/2-templating/4-event-click/vue3/Counter.vue
+++ b/content/2-templating/4-event-click/vue3/Counter.vue
@@ -9,7 +9,5 @@ function incrementCount() {
 
 <template>
   <p>Counter: {{ count }}</p>
-  <button @click="incrementCount">
-    +1
-  </button>
+  <button @click="incrementCount">+1</button>
 </template>

--- a/content/2-templating/6-conditional/vue2/TrafficLight.vue
+++ b/content/2-templating/6-conditional/vue2/TrafficLight.vue
@@ -21,9 +21,7 @@ export default {
 
 <template>
   <div>
-    <button @click="nextLight">
-      Next light
-    </button>
+    <button @click="nextLight">Next light</button>
     <p>Light is: {{ light }}</p>
     <p>
       You must

--- a/content/2-templating/6-conditional/vue3/TrafficLight.vue
+++ b/content/2-templating/6-conditional/vue3/TrafficLight.vue
@@ -11,9 +11,7 @@ function nextLight() {
 </script>
 
 <template>
-  <button @click="nextLight">
-    Next light
-  </button>
+  <button @click="nextLight">Next light</button>
   <p>Light is: {{ light }}</p>
   <p>
     You must

--- a/content/4-component-composition/2-emit-to-parent/vue2/AnswerButton.vue
+++ b/content/4-component-composition/2-emit-to-parent/vue2/AnswerButton.vue
@@ -13,12 +13,8 @@ export default {
 
 <template>
   <div>
-    <button @click="clickYes">
-      YES
-    </button>
+    <button @click="clickYes">YES</button>
 
-    <button @click="clickNo">
-      NO
-    </button>
+    <button @click="clickNo">NO</button>
   </div>
 </template>

--- a/content/4-component-composition/2-emit-to-parent/vue3/AnswerButton.vue
+++ b/content/4-component-composition/2-emit-to-parent/vue3/AnswerButton.vue
@@ -11,11 +11,7 @@ function clickNo() {
 </script>
 
 <template>
-  <button @click="clickYes">
-    YES
-  </button>
+  <button @click="clickYes">YES</button>
 
-  <button @click="clickNo">
-    NO
-  </button>
+  <button @click="clickNo">NO</button>
 </template>

--- a/content/7-webapp-features/2-fetch-data/vue2/App.vue
+++ b/content/7-webapp-features/2-fetch-data/vue2/App.vue
@@ -30,12 +30,8 @@ export default {
 </script>
 
 <template>
-  <p v-if="isLoading">
-    Fetching users...
-  </p>
-  <p v-else-if="error">
-    An error ocurred while fetching users
-  </p>
+  <p v-if="isLoading">Fetching users...</p>
+  <p v-else-if="error">An error ocurred while fetching users</p>
   <ul v-else-if="users">
     <li
       v-for="user in users"

--- a/content/7-webapp-features/2-fetch-data/vue3/App.vue
+++ b/content/7-webapp-features/2-fetch-data/vue3/App.vue
@@ -5,12 +5,8 @@ const { isLoading, error, data: users } = useFetchUsers();
 </script>
 
 <template>
-  <p v-if="isLoading">
-    Fetching users...
-  </p>
-  <p v-else-if="error">
-    An error ocurred while fetching users
-  </p>
+  <p v-if="isLoading">Fetching users...</p>
+  <p v-else-if="error">An error ocurred while fetching users</p>
   <ul v-else-if="users">
     <li
       v-for="user in users"

--- a/frameworks.mjs
+++ b/frameworks.mjs
@@ -62,6 +62,7 @@ export default [
       extends: ["eslint:recommended", "plugin:vue/vue3-recommended"],
       rules: {
         "vue/multi-word-component-names": "off",
+        "vue/singleline-html-element-content-newline": "off",
       },
     },
     playgroundURL: "https://sfc.vuejs.org",
@@ -154,6 +155,7 @@ export default [
       extends: ["eslint:recommended", "plugin:vue/recommended"],
       rules: {
         "vue/multi-word-component-names": "off",
+        "vue/singleline-html-element-content-newline": "off",
       },
     },
     playgroundURL: "",


### PR DESCRIPTION
This makes the code more comparable to Svelte, React, Alpine, etc.

Note: this PR is a follow-up to #187. This time I changed the linter to be consistent with the changes (by setting a custom value for the [vue/singleline-html-element-content-newline](https://eslint.vuejs.org/rules/singleline-html-element-content-newline.html) eslint rule). I believe this change aligns with the spirit of the project, which is to make the various sample code blocks comparable to each other.

Some examples:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/matschik/component-party.dev/assets/478237/a2b278ca-44e6-43b9-b790-b9c5c9d5f814) | ![image](https://github.com/matschik/component-party.dev/assets/478237/3d04d421-e11d-4b1c-9194-2392b015976f) |
| ![image](https://github.com/matschik/component-party.dev/assets/478237/be2fea84-254b-44f3-93f5-a8da3aba6bca) | ![image](https://github.com/matschik/component-party.dev/assets/478237/986be96b-6c1e-4bb4-85b9-07e89899f79a) |
