### PR TITLE
improve: computed calculation in React must be useMemo

### DIFF
--- a/content/1-reactivity/3-computed-state/react/DoubleCount.jsx
+++ b/content/1-reactivity/3-computed-state/react/DoubleCount.jsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 
 export default function DoubleCount() {
   const [count] = useState(10);
-  const doubleCount = count * 2;
+  const doubleCount = useMemo(() => count * 2, [count]);
 
   return <div>{doubleCount}</div>;
 }


### PR DESCRIPTION
With the same functionality to Vue 3's `computed()`, useMemo is a better example for React's computed calculation


![Screenshot 2023-09-25 at 12 22 07 AM](https://github.com/matschik/component-party.dev/assets/57064711/e7efe76c-0cd4-46b3-8cf2-ddd31ae6d327)
