### PR TITLE
Update Svelte 5 examples

### DIFF
--- a/content/2-templating/4-event-click/svelte5/Counter.svelte
+++ b/content/2-templating/4-event-click/svelte5/Counter.svelte
@@ -7,4 +7,4 @@
 </script>
 
 <p>Counter: {count}</p>
-<button on:click={incrementCount}>+1</button>
+<button onclick={incrementCount}>+1</button>

--- a/content/4-component-composition/2-emit-to-parent/svelte5/AnswerButton.svelte
+++ b/content/4-component-composition/2-emit-to-parent/svelte5/AnswerButton.svelte
@@ -1,15 +1,7 @@
 <script>
   let { onYes, onNo } = $props()
-
-  function clickYes() {
-    onYes()
-  }
-
-  function clickNo() {
-    onNo()
-  }
 </script>
 
-<button onclick={clickYes}> YES </button>
+<button onclick={onYes}> YES </button>
 
-<button onclick={clickNo}> NO </button>
+<button onclick={onNo}> NO </button>

--- a/content/4-component-composition/2-emit-to-parent/svelte5/AnswerButton.svelte
+++ b/content/4-component-composition/2-emit-to-parent/svelte5/AnswerButton.svelte
@@ -1,17 +1,15 @@
 <script>
-  import { createEventDispatcher } from "svelte";
-
-  const dispatch = createEventDispatcher();
+  let { onYes, onNo } = $props()
 
   function clickYes() {
-    dispatch("yes");
+    onYes()
   }
 
   function clickNo() {
-    dispatch("no");
+    onNo()
   }
 </script>
 
-<button on:click={clickYes}> YES </button>
+<button onclick={clickYes}> YES </button>
 
-<button on:click={clickNo}> NO </button>
+<button onclick={clickNo}> NO </button>

--- a/content/4-component-composition/2-emit-to-parent/svelte5/App.svelte
+++ b/content/4-component-composition/2-emit-to-parent/svelte5/App.svelte
@@ -13,5 +13,5 @@
 </script>
 
 <p>Are you happy?</p>
-<AnswerButton on:yes={onAnswerYes} on:no={onAnswerNo} />
+<AnswerButton onYes={onAnswerYes} onNo={onAnswerNo} />
 <p style="font-size: 50px;">{isHappy ? "😀" : "😥"}</p>

--- a/content/4-component-composition/3-slot/svelte5/FunnyButton.svelte
+++ b/content/4-component-composition/3-slot/svelte5/FunnyButton.svelte
@@ -1,5 +1,9 @@
+<script>
+  let { children } = $props();
+</script>
+
 <button
   style="background: rgba(0, 0, 0, 0.4); color: #fff; padding: 10px 20px; font-size: 30px; border: 2px solid #fff; margin: 8px; transform: scale(0.9); box-shadow: 4px 4px rgba(0, 0, 0, 0.4); transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s; outline: 0;"
 >
-  <slot />
+  {@render children}
 </button>

--- a/content/4-component-composition/3-slot/svelte5/FunnyButton.svelte
+++ b/content/4-component-composition/3-slot/svelte5/FunnyButton.svelte
@@ -5,5 +5,5 @@
 <button
   style="background: rgba(0, 0, 0, 0.4); color: #fff; padding: 10px 20px; font-size: 30px; border: 2px solid #fff; margin: 8px; transform: scale(0.9); box-shadow: 4px 4px rgba(0, 0, 0, 0.4); transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s; outline: 0;"
 >
-  {@render children}
+  {@render children()}
 </button>

--- a/content/4-component-composition/4-slot-fallback/svelte5/FunnyButton.svelte
+++ b/content/4-component-composition/4-slot-fallback/svelte5/FunnyButton.svelte
@@ -1,7 +1,13 @@
+<script>
+  let { children } = $props();
+</script>
+
 <button
   style="background: rgba(0, 0, 0, 0.4); color: #fff; padding: 10px 20px; font-size: 30px; border: 2px solid #fff; margin: 8px; transform: scale(0.9); box-shadow: 4px 4px rgba(0, 0, 0, 0.4); transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s; outline: 0;"
 >
-  <slot>
+  {#if children}
+    {@render children}
+  {:else}
     <span>No content found</span>
-  </slot>
+  {/if}
 </button>

--- a/content/4-component-composition/4-slot-fallback/svelte5/FunnyButton.svelte
+++ b/content/4-component-composition/4-slot-fallback/svelte5/FunnyButton.svelte
@@ -6,7 +6,7 @@
   style="background: rgba(0, 0, 0, 0.4); color: #fff; padding: 10px 20px; font-size: 30px; border: 2px solid #fff; margin: 8px; transform: scale(0.9); box-shadow: 4px 4px rgba(0, 0, 0, 0.4); transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s; outline: 0;"
 >
   {#if children}
-    {@render children}
+    {@render children()}
   {:else}
     <span>No content found</span>
   {/if}

--- a/content/7-webapp-features/1-render-app/svelte5/app.js
+++ b/content/7-webapp-features/1-render-app/svelte5/app.js
@@ -1,6 +1,7 @@
+import { mount } from "svelte"
 import App from "./App.svelte";
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById("app"),
 });
 


### PR DESCRIPTION
This PR updates some of the Svelte 5 examples to reflect some changes made since the original Svelte 5 announcements:

- [Components are now functions instead of classes](https://svelte-5-preview.vercel.app/docs/breaking-changes#components-are-no-longer-classes), and so require the new `mount` function to be rendered.
- The `on:` directive and `createEventDispatcher` are now deprecated in favor of using regular callback props (similarly to React)
- Slots are deprecated in favor of snippets: a new way to create reusable markup and pass it down to components.

Please let me know if I missed anything or if something needs to be updated to better fit Svelte 5's intended use!

Closes #201 