### PR TITLE
Convert Angular input examples into standalone component & switch to two-way binding

### DIFF
--- a/content/6-form-input/1-input-text/angular/input-hello.component.ts
+++ b/content/6-form-input/1-input-text/angular/input-hello.component.ts
@@ -1,13 +1,14 @@
 import { Component } from "@angular/core";
+import { CommonModule } from '@angular/common';
+import {FormsModule} from "@angular/forms";
 
 @Component({
   selector: "app-input-hello",
-  template: `<input [value]="text" (change)="handleInputChange($event)" />`,
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `<p>{{text}}</p>
+  <input [(ngModel)]="text">`,
 })
 export class InputHelloComponent {
   text = "";
-
-  handleInputChange(event: Event) {
-    this.text = (event.target as HTMLInputElement).value;
-  }
 }

--- a/content/6-form-input/2-checkbox/angular/is-available.component.ts
+++ b/content/6-form-input/2-checkbox/angular/is-available.component.ts
@@ -1,13 +1,16 @@
 import { Component } from "@angular/core";
+import { CommonModule } from '@angular/common';
+import {FormsModule} from "@angular/forms";
 
 @Component({
   selector: "app-is-available",
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   template: `
     <input
       id="is-available"
       type="checkbox"
-      [checked]="isAvailable"
-      (change)="handleChange()"
+      [(ngModel)] = "isAvailable"
     />
     <label for="is-available">Is available</label>
   `,
@@ -15,7 +18,4 @@ import { Component } from "@angular/core";
 export class IsAvailableComponent {
   isAvailable = false;
 
-  handleChange() {
-    this.isAvailable = !this.isAvailable;
-  }
 }

--- a/content/6-form-input/3-radio/angular/pick-pill.component.ts
+++ b/content/6-form-input/3-radio/angular/pick-pill.component.ts
@@ -1,33 +1,31 @@
 import { Component } from "@angular/core";
+import { CommonModule } from '@angular/common';
+import {FormsModule} from "@angular/forms";
 
 @Component({
   selector: "app-pick-pill",
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   template: `
     <div>Picked: {{ picked }}</div>
 
     <input
       id="blue-pill"
-      [checked]="picked === 'blue'"
       type="radio"
       value="blue"
-      (change)="handleChange($event)"
+      [(ngModel)]="picked"
     />
     <label for="blue-pill">Blue pill</label>
 
     <input
       id="red-pill"
-      [checked]="picked === 'red'"
       type="radio"
       value="red"
-      (change)="handleChange($event)"
+      [(ngModel)]="picked"
     />
     <label for="red-pill">Red pill</label>
   `,
 })
 export class PickPillComponent {
   picked = "red";
-
-  handleChange(event) {
-    this.picked = event.target.value;
-  }
 }

--- a/content/6-form-input/4-select/angular/color-select.component.ts
+++ b/content/6-form-input/4-select/angular/color-select.component.ts
@@ -1,9 +1,13 @@
 import { Component } from "@angular/core";
+import { CommonModule } from '@angular/common';
+import {FormsModule} from "@angular/forms";
 
 @Component({
   selector: "app-color-select",
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   template: `
-    <select [value]="selectedColorId" (change)="handleChange($event)">
+    <select [(ngModel)]="selectedColorId">
       <option
         *ngFor="let color of colors"
         [value]="color.id"
@@ -23,8 +27,4 @@ export class ColorSelectComponent {
     { id: 3, text: "green" },
     { id: 4, text: "gray", isDisabled: true },
   ];
-
-  handleChange(event) {
-    this.selectedColorId = event.target.value;
-  }
 }


### PR DESCRIPTION
Angular introduced [Standalone Component](https://angular.io/guide/standalone-components) since v14(as developer preview feature). It became stable in v15 and now in v17, is enabled by default when generating components using cli. Since it eliminates the need for ngModule, it is easier to manage imports for individual components like the examples here. I am able to show the use of built-in modules without adding a new ngModule file to the example.  

Angular's built-in templated driven [FormsModule](https://angular.io/guide/forms-overview#setup-in-template-driven-forms) allows two-way binding, which makes more sense and is easier to implement for simple input examples.