### PR TITLE
fix Svelte 5 on-mount

### DIFF
--- a/content/3-lifecycle/1-on-mount/svelte5/PageTitle.svelte
+++ b/content/3-lifecycle/1-on-mount/svelte5/PageTitle.svelte
@@ -1,5 +1,5 @@
 <script>
-  let pageTitle = "";
+  let pageTitle = $state("");
   $effect(() => {
     pageTitle = document.title;
   });


### PR DESCRIPTION
`$effect()` runs after the component gets mounted and rendered, but `pageTitle` isn't reactive. Thus, the page won't re-render with the new value. For this logic, it's better to use `$effert.pre()` - it runs before mounting and the first rendering. But as the example concerns the on-mount event, it makes more sense to make `pageTitle` reactive.

You can try both solutions on [the Svelte 5 playground](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAA1WOwQqDMAyGXyWEHRTGvDtX2BvssNvcQWocgVqLjY5Rffe1Gwiewv-R_0sCdmzIY_kIaJuesMSrc3hE-bgU_ExGKGY_TKNOpPJ6ZCeqtgCGBFzzojuLIbhAjWxZGgNzYyaq8ZyWDtR1pCXLcrgoCAnBrtUOeurJykl-YFmix9J7J1nzOKpiux2DU7cogX-JfQlhk65V4VR8uh9a7phaLGWcaH2uXwXAXF7vAAAA).