### PR TITLE
Fix framework navbar scroll

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -143,7 +143,7 @@
   <Aside />
   <div class="pb-8 w-10 grow">
     <div
-      class="no-scroll flex px-6 lg:px-20 py-2 sticky top-0 z-20 w-full backdrop-blur bg-gray-900/80 border-b border-gray-700 whitespace-nowrap overflow-x-auto"
+      class="flex px-6 lg:px-20 py-2 sticky top-0 z-20 w-full backdrop-blur bg-gray-900/80 border-b border-gray-700 whitespace-nowrap overflow-x-auto"
     >
       {#each [...frameworksSelected, ...frameworksNotSelected] as framework (framework.id)}
         <button


### PR DESCRIPTION
As reported by @khang-nd, the framework navbar does not allow scrolling on larger zoom screens or smaller screens.

To fix that, I removed the class `no-scroll` from the navbar; allowing the user to better navigate when choosing frameworks.