### PR TITLE
Fix incorrect Angular component selectors

### DIFF
--- a/content/4-component-composition/3-slot/angular/funny-button.component.ts
+++ b/content/4-component-composition/3-slot/angular/funny-button.component.ts
@@ -1,7 +1,7 @@
 import { Component } from "@angular/core";
 
 @Component({
-  selector: "app-root",
+  selector: "app-funny-button",
   styleUrls: ["./funny-button.component.css"],
   template: `
     <button>

--- a/content/4-component-composition/4-slot-fallback/angular/funny-button.component.ts
+++ b/content/4-component-composition/4-slot-fallback/angular/funny-button.component.ts
@@ -1,7 +1,7 @@
 import { Component, ContentChild, TemplateRef } from "@angular/core";
 
 @Component({
-  selector: "app-root",
+  selector: "app-funny-button",
   styleUrls: ["./funny-button.component.css"],
   template: `
     <button>


### PR DESCRIPTION
Some Angular components don't have correct selector, renaming them to match the ones used in parent components.