### PR TITLE
fix(content): update PageTitle.svelte to match other frameworks

### DIFF
--- a/content/3-lifecycle/1-on-mount/svelte4/PageTitle.svelte
+++ b/content/3-lifecycle/1-on-mount/svelte4/PageTitle.svelte
@@ -6,4 +6,4 @@
   });
 </script>
 
-<p>Page title is: {pageTitle}</p>
+<p>Page title: {pageTitle}</p>

--- a/content/3-lifecycle/1-on-mount/svelte5/PageTitle.svelte
+++ b/content/3-lifecycle/1-on-mount/svelte5/PageTitle.svelte
@@ -5,4 +5,4 @@
   });
 </script>
 
-<p>Page title is: {pageTitle}</p>
+<p>Page title: {pageTitle}</p>


### PR DESCRIPTION
The other frameworks such as React do not include "is".