### PR TITLE
fix: content shifting when the copy button appears

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -35,7 +35,7 @@
         {#if frameworksSelected.length > 0}
           <button
             type="button"
-            class="flex items-center space-x-2 rounded bg-gray-800 px-2 py-1.5 text-sm text-white shadow-sm hover:bg-white/15"
+            class="flex items-center space-x-2 rounded border border-gray-700 border-opacity-50 bg-gray-900 px-3 py-1 text-sm text-white transition-all hover:bg-gray-800"
             aria-label="Copy framework selection link"
             on:click={copyShareLink}
           >


### PR DESCRIPTION
I noticed that when any framework is selected the "Share" button appears. Since that button has a padding of `py-1.5` and the GitHub button has a padding of `py-1`, it is slightly larger than the GitHub button which is causing the Header/nav to expand in height by a few pixels; causing a layout shift:

https://github.com/matschik/component-party.dev/assets/47110839/bd90843a-a130-46e0-9d4e-a1116ddce281

Just changing the share button's padding to `py-1` fixes the shifting, however, in my opinion it looks a bit off next to the GitHub button:
![Screenshot 2024-05-01 at 6  05 05@2x](https://github.com/matschik/component-party.dev/assets/47110839/dc345048-e521-4238-9c98-d1db54c635c5)

Because as you can see, the share button is slightly smaller than the GitHub button since it doesn't have a border:
![Screenshot 2024-05-01 at 6  13 14@2x](https://github.com/matschik/component-party.dev/assets/47110839/3dfb93fd-32ee-434f-ba27-15e5b6c6d546)

So I've changed the styling to include a border and also match the framework buttons, hopefully that's ok:
![Screenshot 2024-05-01 at 6  14 40@2x](https://github.com/matschik/component-party.dev/assets/47110839/827b2be7-2ab8-46a5-87de-69f429003a6e)
 
As you can see, the shifting is gone after these changes:

https://github.com/matschik/component-party.dev/assets/47110839/6d1b36c3-78be-4acc-a571-2371caab24d1

