### PR TITLE
fix: content shifting when the copy button appears on mobile

### DIFF
--- a/src/components/GithubStarButton.svelte
+++ b/src/components/GithubStarButton.svelte
@@ -66,12 +66,14 @@
   aria-label={`Star ${REPOSITORY_PATH} on GitHub`}
   on:click={onButtonClick}
 >
-  <span class="space-x-2 flex items-center border-r border-[#373b43] px-2">
-    <GithubIcon class="size-[1.1rem]" />
-    <span>Star</span>
+  <span
+    class="flex items-center border-[#373b43] px-3 sm:space-x-2 sm:border-r"
+  >
+    <GithubIcon class="size-[1.3rem] sm:size-[1.1rem]" />
+    <span class="hidden sm:inline">Star</span>
   </span>
   {#if isFetchingStarCount || starCount !== 0}
-    <div class="h-full flex justify-center items-center pl-3 pr-3">
+    <div class="hidden h-full items-center justify-center px-3 sm:flex">
       {#if isFetchingStarCount && starCount === 0}
         <svg
           class="animate-spin size-4 mx-1"

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -35,7 +35,7 @@
         {#if frameworksSelected.length > 0}
           <button
             type="button"
-            class="flex items-center space-x-2 rounded bg-gray-800 px-2 py-1.5 text-sm text-white shadow-sm hover:bg-white/15"
+            class="flex items-center space-x-2 rounded border border-gray-700 border-opacity-50 bg-gray-900 px-3 py-1 text-sm text-white transition-all hover:bg-gray-800"
             aria-label="Copy framework selection link"
             on:click={copyShareLink}
           >


### PR DESCRIPTION
Same issue as #235, but on mobile and slightly different:

https://github.com/matschik/component-party.dev/assets/47110839/981fd534-3cb6-4287-ba32-cb656c050acb

The problem is that the title gets wrapped because of the share button being added and the GitHub button taking a lot of space.

An easy fix is to just hide the text and numbers on small screens, however, that will cause the GitHub button to look off next to the share button:
![Screenshot 2024-05-01 at 11  17 07@2x](https://github.com/matschik/component-party.dev/assets/47110839/0e37963a-ba3c-43ac-9079-d349c73f3a75)

To fix this, I set the horizontal padding and the size of the icon to the same values as the share button:
![Screenshot 2024-05-01 at 11  19 31@2x](https://github.com/matschik/component-party.dev/assets/47110839/85f0a44a-a61c-4f8d-8d96-cf058cf476c6)

As you can see, the shifting is gone after these changes:

https://github.com/matschik/component-party.dev/assets/47110839/f86919e4-6e14-4357-bf31-b55368b27161

