### PR TITLE
refactor: use vue composition api instead of provide-inject for context

### DIFF
--- a/content/4-component-composition/5-context/vue3/App.vue
+++ b/content/4-component-composition/5-context/vue3/App.vue
@@ -1,18 +1,6 @@
 <script setup>
-import { ref, provide } from "vue";
 import UserProfile from "./UserProfile.vue";
-
-const user = ref({
-  id: 1,
-  username: "unicorn42",
-  email: "unicorn42@example.com",
-});
-
-function updateUsername(username) {
-  user.value.username = username;
-}
-
-provide("user", { user, updateUsername });
+import { user } from "./userStore";
 </script>
 
 <template>

--- a/content/4-component-composition/5-context/vue3/UserProfile.vue
+++ b/content/4-component-composition/5-context/vue3/UserProfile.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { inject } from "vue";
-const { user, updateUsername } = inject("user");
+import { user, updateUsername } from "./userStore";
 </script>
 
 <template>
@@ -8,7 +7,7 @@ const { user, updateUsername } = inject("user");
     <h2>My Profile</h2>
     <p>Username: {{ user.username }}</p>
     <p>Email: {{ user.email }}</p>
-    <button @click="() => updateUsername('Jane')">
+    <button @click="updateUsername('Jane')">
       Update username to Jane
     </button>
   </div>

--- a/content/4-component-composition/5-context/vue3/userStore.js
+++ b/content/4-component-composition/5-context/vue3/userStore.js
@@ -1,0 +1,11 @@
+import { ref } from "vue";
+export const user = ref({
+  id: 1,
+  username: "unicorn42",
+  email: "unicorn42@example.com",
+});
+
+
+export function updateUsername(username) {
+  user.value.username = username;
+}


### PR DESCRIPTION
Use of the recommended Vue Composition API capabilities instead of provide/inject API for global context stores.
It is recommende for being a cleaner, and more maintainable and easy to understand closer to native JS code.