### PR TITLE
fix(qwik): use signal to track DOM ref

### DIFF
--- a/content/2-templating/5-dom-ref/qwik/InputFocused.tsx
+++ b/content/2-templating/5-dom-ref/qwik/InputFocused.tsx
@@ -1,9 +1,12 @@
-import { component$, useVisibleTask$, useRef } from "@builder.io/qwik";
+import { component$, useVisibleTask$, useSignal } from "@builder.io/qwik";
 
 export const InputFocused = component$(() => {
-  const inputElement = useRef(null);
-
-  useVisibleTask$(() => inputElement.current.focus());
+  const inputElement = useSignal<HTMLInputElement>();
+  
+  useVisibleTask$(({ track }) => {
+    const el = track(inputElement);
+    el?.focus();
+  });
 
   return <input type="text" ref={inputElement} />;
 });


### PR DESCRIPTION
Ref. [Qwik getting hold of a DOM element](https://qwik.dev/docs/components/overview/#getting-hold-of-dom-element)