### PR TITLE
chore: default to svelte 5 instead of svelte 4

### DIFF
--- a/src/Index.svelte
+++ b/src/Index.svelte
@@ -113,7 +113,7 @@
     }
 
     if (useDefaults && frameworkIdsSelectedOnInit.length === 0) {
-      frameworkIdsSelectedOnInit = ["react", "svelte4"];
+      frameworkIdsSelectedOnInit = ["react", "svelte5"];
     }
 
     frameworkIdsSelected = new SvelteSet(frameworkIdsSelectedOnInit);


### PR DESCRIPTION
now that Svelte 5 is out, it probably makes sense to use it instead