### PR TITLE
move Svelte 4 vs Svelte 5 and Angular vs Angular Renaissance in comparison footer

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -48,6 +48,7 @@ const footerNavigation = [
   {
     title: "Comparing Legacy version & Current Version",
     links: [
+      { name: "Svelte 4 vs Svelte 5", url: "/compare/svelte4-vs-svelte5" },
       { name: "Vue 2 vs Vue 3", url: "/compare/vue2-vs-vue3" },
       {
         name: "Aurelia 1 vs Aurelia 2",
@@ -66,7 +67,6 @@ const footerNavigation = [
         name: "Angular vs Angular Renaissance",
         url: "/compare/angular-vs-angularRenaissance",
       },
-      { name: "Svelte 4 vs Svelte 5", url: "/compare/svelte4-vs-svelte5" },
       {
         name: "Ember Octane vs Ember Polaris",
         url: "/compare/emberOctane-vs-emberPolaris",

--- a/vite.config.js
+++ b/vite.config.js
@@ -64,10 +64,6 @@ const footerNavigation = [
     title: "Comparing Current Version & Upcoming Version",
     links: [
       {
-        name: "Angular vs Angular Renaissance",
-        url: "/compare/angular-vs-angularRenaissance",
-      },
-      {
         name: "Ember Octane vs Ember Polaris",
         url: "/compare/emberOctane-vs-emberPolaris",
       },


### PR DESCRIPTION
This PR:
- Moves Svelte 4 vs Svelte 5 from Current vs Upcoming to Legacy vs Current now that Svelte 5 is released.
- Removes Angular vs Angular Renaissance from Current vs Upcoming since it is already in Legacy vs Current.