### PR TITLE
Fix: `computed state` in most of the framework have cache, so use `useMemo`

### DIFF
--- a/content/1-reactivity/3-computed-state/react/DoubleCount.jsx
+++ b/content/1-reactivity/3-computed-state/react/DoubleCount.jsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 
 export default function DoubleCount() {
   const [count] = useState(10);
-  const doubleCount = count * 2;
+  const doubleCount = useMemo(() => count * 2, [count]);
 
   return <div>{doubleCount}</div>;
 }


### PR DESCRIPTION
If simply use `const doubleCount = count * 2`, each time the function is re-rendered, the `doubleCount` will be triggered to re-calculate, which does not meet most of the mechanisms of frameworks. Using `useMemo`, `doubleCount` just updates when its dependency `count` updates!