### PR TITLE
refactor(ripple): use new switch-case syntax in example 2-6

### DIFF
--- a/content/2-templating/6-conditional/ripple/TrafficLight.ripple
+++ b/content/2-templating/6-conditional/ripple/TrafficLight.ripple
@@ -15,12 +15,16 @@ export component TrafficLight() {
   <p>{`Light is ${@light}`}</p>
   <p>
     {"You must "}
-    if (@light === "red") {
-      <span>{"STOP"}</span>
-    } else if (@light === "orange") {
-      <span>{"SLOW DOWN"}</span>
-    } else if (@light === "green") {
-      <span>{"GO"}</span>
+    switch (@light) {
+      case "red":
+        <span>{"STOP"}</span>;
+        break;
+      case "orange":
+        <span>{"SLOW DOWN"}</span>;
+        break;
+      case "green":
+        <span>{"GO"}</span>;
+        break;
     }
   </p>
 }


### PR DESCRIPTION
ripple recently added support for switch case syntax, i thought it would make sense to use those in this example :)